### PR TITLE
Fix autocorrect typo of TRS 攏咧

### DIFF
--- a/documentation/hanzi_biaozhun_geshi/hanzi_zhuyin.md
+++ b/documentation/hanzi_biaozhun_geshi/hanzi_zhuyin.md
@@ -67,7 +67,7 @@
 	<br>
 
 	<ruby class="reading romanization">
-		伊<rt>i</rt>逐工<rt>ta̍k-kang</rt>攏咧<rt>lóng-the</rt>
+		伊<rt>i</rt>逐工<rt>ta̍k-kang</rt>攏咧<rt>lóng-teh</rt>
 		笑<rt>siàu</rt>電影<rt>tiān-iánn</rt>，<rt></rt>
 		聽<rt>thiann</rt>阿啄仔<rt>a-tok-á</rt>的<rt>ê</rt>
 		<abbr lang="en" title="compact disc">CD</abbr>。


### PR DESCRIPTION
The proper markup is 攏咧 lóng-teh 

咧 https://www.moedict.tw/!%E5%92%A7

Reported by Liz Lin.
